### PR TITLE
Only report that files were changed if they actually were

### DIFF
--- a/sort_requirements/script.py
+++ b/sort_requirements/script.py
@@ -80,8 +80,6 @@ def main():
             )
 
         if original != modified:
-            changed += 1
-
             if args.diff:
                 sys.stderr.writelines(
                     difflib.unified_diff(
@@ -96,6 +94,7 @@ def main():
             if args.check or args.diff:
                 failed.append(path)
             else:
+                changed += 1
                 with open(path, "w") as f:
                     f.write(modified)
 

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -124,7 +124,7 @@ class TestScript(object):
         assert cmd.returncode == 1
         assert re.match(pattern, cmd.stderr.decode("utf8")) is not None
         assert cmd.stderr.decode("utf8").endswith(
-            "All done! 🎉\n1 file(s) changed, 0 file(s) unchanged.\n"
+            "All done! 🎉\n1 file(s) unchanged.\n"
         )
 
         # Ensure the file is unchanged
@@ -163,7 +163,7 @@ class TestScript(object):
         assert cmd.returncode == 1
         assert re.match(pattern, cmd.stderr.decode("utf8")) is not None
         assert cmd.stderr.decode("utf8").endswith(
-            "All done! 🎉\n2 file(s) changed, 0 file(s) unchanged.\n"
+            "All done! 🎉\n2 file(s) unchanged.\n"
         )
 
         # Ensure the files are unchanged
@@ -191,9 +191,7 @@ class TestScript(object):
 
         assert cmd.returncode == 1
         assert output.startswith(diff)
-        assert output.endswith(
-            "All done! 🎉\n1 file(s) changed, 0 file(s) unchanged.\n"
-        )
+        assert output.endswith("All done! 🎉\n1 file(s) unchanged.\n")
 
         # Ensure the file is unchanged
         with open(tfp, "r") as f:


### PR DESCRIPTION
Thanks for the great tool, it's just what I was looking for (and was about to write!)

This PR fixes the final reporting line to avoid saying that some files were changed when in fact they weren't.

Without this fix, running it as follows gives a confusing message at the end:
```
> sort-requirements --check constraints.txt
Some files need sorting:
- constraints.txt

All done! 🎉
1 file(s) changed, 0 file(s) unchanged
```
I was surprised to see `1 file(s) changed` given the `--check` argument explicitly says "Don't write the files back, ..."

Sure enough my file hadn't been modified, it's just a bug in the counting of `changed`.